### PR TITLE
fix: shortcut error in loop

### DIFF
--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 from typing import Any
 from typing import Callable
@@ -114,7 +115,7 @@ class Choice:
         """
 
         if isinstance(c, Choice):
-            return c
+            return copy.copy(c)
         elif isinstance(c, str):
             return Choice(c, c)
         else:


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->
When we use the `select` method within a loop, and the `Choice` parameter sequence is defined outside the loop, shortcut keys in alternating loops are presented in a doubled manner of the actual values.

example:
```py
import questionary
from questionary import Choice

options = [Choice("One"), Choice("Two"), Choice("Three")]
for _ in range(4):
    option = questionary.select("Title:", options, use_shortcuts=True).ask()
```
![2023-11-28-3421](https://github.com/viniciusdc/questionary/assets/54403862/a62d09ff-78cd-44c5-9f1d-15418e425b61)


**How did you solve it?**
<!-- A detailed description of your implementation. -->

The root cause is that, during the initialization of the `InquirerControl.choices` in the `_init_choices` process, when a `Choice` object is instantiated with another `Choice` object as a parameter, it directly references and passes the return result. This causes the `shortcut_key` parameter state of the `Choice` object to be retained in the loop, leading to the aforementioned issue.
We can resolve this issue by modifying the `build` method of the `Choice` class. When accepting a Choice-type parameter, we can return the result using a shallow copy."

```py
import copy

if isinstance(c, Choice):
   return copy.copy(c)
```

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
